### PR TITLE
Use Firebase functions rather than fcm to send notifications

### DIFF
--- a/HabitatAppSupport/module.json
+++ b/HabitatAppSupport/module.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/ardevd/HabitatAppSupportModule",
   "icon": "icon.png",
   "moduleName": "HabitatAppSupport",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "maturity": "beta",
   "defaults": {
     "title": "__m_title__",


### PR DESCRIPTION
Instead of the module calling FCM directly we pass notification data to functions instead. This removes the need to store the FCM token key. 

Fixes #1 